### PR TITLE
Comprehensive improvements for alert formatting

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+((web-mode . (;; four space indentation for JS
+              (web-mode-code-indent-offset . 4)
+              ;; no consistent code formatting
+              (apheleia-inhibit . t))))

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:24
 
 ENV APP_PORT="3000"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24
+FROM node:24-alpine
 
 ENV APP_PORT="3000"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
+        "diff": "^8.0.2",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
         "matrix-js-sdk": "^12.5.0",
@@ -1480,10 +1481,10 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "node_modules/diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "dev": true,
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -3614,6 +3615,16 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/mocha/node_modules/glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
@@ -5064,6 +5075,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/sinon/node_modules/has-flag": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "sinon": "^11.1.2"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 22"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "sinon": "^11.1.2"
   },
   "dependencies": {
+    "diff": "^8.0.2",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "matrix-js-sdk": "^12.5.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bot"
   ],
   "engines": {
-    "node": ">= 14"
+    "node": ">= 22"
   },
   "author": "Jason Robinson",
   "license": "MIT",

--- a/src/utils.js
+++ b/src/utils.js
@@ -472,6 +472,15 @@ const utils = {
                 parts.push(` <br><b>${label}</b>: ${value}`);
             }
 
+            let hasCommonAnnotation = false;
+            for (const [annotation, value] of Object.entries(data.commonAnnotations)) {
+                if (!hasCommonAnnotation) {
+                    parts.push(`<br>`);
+                    hasCommonAnnotation;
+                }
+                parts.push(` <br><b>${annotation}</b>: ${value}`);
+            }
+
             if (alerts.length > 1) {
                 parts.push(` <br>${nbsp}`);
                 let alertNum = 1;
@@ -489,6 +498,21 @@ const utils = {
                         if (data.commonLabels[label]) continue;
                         parts.push(` <br><b>${label}</b>: ${value}`);
                     }
+                    let hasAnnotation = false;
+                    for (const [annotation, value] of Object.entries(alert.annotations)) {
+                        if (data.commonAnnotations[annotation]) continue;
+                        if (
+                            annotation === "summary" ||
+                            annotation.startsWith("logs_")
+                        ) {
+                            continue;
+                        }
+                        if (!hasAnnotation) {
+                            parts.push(`<br>`);
+                            hasAnnotation = true;
+                        }
+                        parts.push(` <br><b>${annotation}</b>: ${value}`);
+                    }
                     parts.push(` <br>${nbsp}</details>`);
                     alertNum += 1;
                 }
@@ -499,7 +523,7 @@ const utils = {
 
         const urls = [];
 
-        if (process.env.GRAFANA_URL) {
+        if (process.env.GRAFANA_URL && process.env.GRAFANA_DATASOURCE) {
             const generatorURLs = new Set(data.alerts.map(alert => alert.generatorURL));
             let grafanaNum = 1;
             for (const generatorURL of generatorURLs) {
@@ -527,7 +551,7 @@ const utils = {
                     "/explore?orgId=1&left=" +
                     encodeURIComponent(JSON.stringify(left))
                 );
-                const name = generatorURLs.size > 1 ? `Grafana ${grafanaNum}` : "Grafana";
+                const name = generatorURLs.size > 1 ? `Alert query ${grafanaNum}` : "Alert query";
                 urls.push(`<a href="${url}">📈 ${name}</a>`);
                 grafanaNum += 1;
             }
@@ -543,7 +567,7 @@ const utils = {
                 encodeURIComponent(filter) +
                 "}"
             );
-            urls.push(`<a href="${url}">🔇 Alertmanager</a>`);
+            urls.push(`<a href="${url}">🔇 Silence</a>`);
         }
 
         if (urls.length > 0) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -444,7 +444,7 @@ const utils = {
                         if (alert.labels.env) {
                             alert.summary += ` (${alert.labels.env})`;
                         }
-                        if (!alert.labels.logs_url && !alert.labels.logs_template) {
+                        if (!alert.annotations.logs_url && !alert.annotations.logs_template) {
                             for (const labelSet of [
                                 ["env", "cluster_id", "namespace", "pod"],
                                 ["env", "cluster_id", "nodename", "exported_job", "level"],

--- a/src/utils.js
+++ b/src/utils.js
@@ -155,9 +155,13 @@ const mergeStrings = (strings) => {
                 }
             }
         }
-        // Note that even though the ranges are inclusive-exclusive,
-        // we are treating them as inclusive-inclusive here because we
-        // want adjacent substrings to be picked up, as well.
+        // We're now iterating through the picked-out characters and
+        // the varying text ranges in parallel, incrementing either
+        // one when the other has gotten too far ahead. Our goal is to
+        // select for the particular picked-out characters that either
+        // fall strictly within a varying range (for unchanged
+        // characters) or fall within-or-adjacent-to a varying range
+        // (for added characters).
         const varyingParts = [];
         let idx = 0, done = false;
         for (const range of varyingRanges) {
@@ -193,6 +197,11 @@ const mergeStrings = (strings) => {
         varyingLists.push(varyingParts);
     }
 
+    // Finally, we iterate through the varying and unchanged text
+    // ranges in parallel, alternating between them (starting at
+    // whichever one covers index zero) and inserting the
+    // corresponding slices from the underlying strings, in order to
+    // construct the final merged text.
     let varyingIdx = 0, unchangedIdx = 0;
     let onVarying = varyingRanges[0].start === 0;
 
@@ -509,7 +518,7 @@ const utils = {
                 if (omitAnnotation(annotation)) continue;
                 if (!hasCommonAnnotation) {
                     parts.push(`<br>`);
-                    hasCommonAnnotation;
+                    hasCommonAnnotation = true;
                 }
                 parts.push(` <br><b>${annotation}</b>: ${value}`);
             }
@@ -653,7 +662,7 @@ const utils = {
                     const alerts = data.alerts.filter(
                         alert => (
                             alert.annotations.logs_template === logsTemplate &&
-                            alert.annotations.logs_datasource || defaultDatasource === logsDatasource
+                            (alert.annotations.logs_datasource || defaultDatasource) === logsDatasource
                         ),
                     );
                     const expr = logsTemplate.replace(/=~?"\$([a-z0-9_]+)"/g, (_, label) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 const jsdiff = require('diff');
 
 const segmentString = (string) => {
-    return Array.from(string.matchAll(/[a-z0-9.-]+|[^a-z0-9.-]+/gi).map(match => match[0]));
+    return Array.from(string.matchAll(/[a-z0-9.-]+|[^a-z0-9.-]+/gi), match => match[0]);
 }
 
 const diffSegmented = (left, right) => {
@@ -203,7 +203,7 @@ const mergeStrings = (strings) => {
     // corresponding slices from the underlying strings, in order to
     // construct the final merged text.
     let varyingIdx = 0, unchangedIdx = 0;
-    let onVarying = varyingRanges[0].start === 0;
+    let onVarying = unchangedRanges[0].start > 0;
 
     let combined = [];
     while (
@@ -665,6 +665,7 @@ const utils = {
                             (alert.annotations.logs_datasource || defaultDatasource) === logsDatasource
                         ),
                     );
+                    if (alerts.length === 0) continue;
                     const expr = logsTemplate.replace(/=~?"\$([a-z0-9_]+)"/g, (_, label) => {
                         const values = new Set(alerts.map(alert => alert.labels[label]).filter(Boolean));
                         const regex = values.size > 0 ? [...values].join("|") : ".+";

--- a/src/utils.js
+++ b/src/utils.js
@@ -438,8 +438,8 @@ const utils = {
                                 ["env", "cluster_id", "nodename", "exported_job", "level"],
                             ]) {
                                 if (labelSet.every(l => alert.labels[l])) {
-                                    alert.logs_template = (
-                                        "{" + labelSet.map(l => l + `=$` + l).join(",") + "}"
+                                    alert.annotations.logs_template = (
+                                        "{" + labelSet.map(l => `${l}="$${l}"`).join(",") + "}"
                                     );
                                     break;
                                 }
@@ -637,8 +637,10 @@ const utils = {
                 );
                 for (const logsDatasource of logsDatasources) {
                     const alerts = data.alerts.filter(
-                        alert.annotations.logs_template === logsTemplate &&
-                        alert.annotations.logs_datasource || defaultDatasource === logsDatasource
+                        alert => (
+                            alert.annotations.logs_template === logsTemplate &&
+                            alert.annotations.logs_datasource || defaultDatasource === logsDatasource
+                        ),
                     );
                     const expr = logsTemplate.replace(/=~?"\$([a-z0-9_]+)"/g, function(_, label) {
                         const values = new Set(alerts.map(alert => alert.labels[label]).filter(Boolean));
@@ -653,7 +655,7 @@ const utils = {
         let logsNum = 1;
         for (const logsURL of logsURLs) {
             const name = logsURLs.size > 1 ? `Logs ${logsNum}` : "Logs";
-            urls.push(`<a href="${logsURL}>🪵 ${name}</a>`);
+            urls.push(`<a href="${logsURL}">🪵 ${name}</a>`);
         }
 
         if (urls.length > 0) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -223,28 +223,6 @@ const mergeStrings = (strings) => {
     return combined.join("");
 }
 
-// console.log(mergeStrings([
-//     "ArgoCD app stage1 sync status is Unknown in cluster prod/edge-eu-cuddly-pants",
-//     "ArgoCD app stage2 sync status is Unknown in cluster prod/edge-eu-cuddly-pants",
-//     "ArgoCD app stage1 sync status is OutOfSync in cluster prod/edge-eu-cuddly-pants",
-//     "ArgoCD app stage1 sync status is Unknown in cluster staging/edge-na-rosy-gift",
-// ]))
-
-console.log(mergeStrings([
-    "ArgoCD app stage1 sync status is Unknown in cluster prod/edge-eu-cuddly-pants",
-    "ArgoCD app stage2 sync status is Unknown in cluster prod/edge-eu-cuddly-pants",
-    "ArgoCD app stage3 sync status is Unknown in cluster prod/edge-eu-cuddly-pants",
-    "ArgoCD app stage1 sync status is Unknown in cluster staging/edge-na-rosy-gift",
-    "ArgoCD app stage2 sync status is Unknown in cluster staging/edge-na-rosy-gift",
-    "ArgoCD app stage3 sync status is Unknown in cluster staging/edge-na-rosy-gift",
-    "ArgoCD app stage1 sync status is OutOfSync in cluster prod/edge-eu-cuddly-pants",
-    "ArgoCD app stage2 sync status is OutOfSync in cluster prod/edge-eu-cuddly-pants",
-    "ArgoCD app stage3 sync status is OutOfSync in cluster prod/edge-eu-cuddly-pants",
-    "ArgoCD app stage1 sync status is OutOfSync in cluster staging/edge-na-rosy-gift",
-    "ArgoCD app stage2 sync status is OutOfSync in cluster staging/edge-na-rosy-gift",
-    "ArgoCD app stage3 sync status is OutOfSync in cluster staging/edge-na-rosy-gift",
-]))
-
 const utils = {
 
     getRoomForReceiver: receiver => {
@@ -437,6 +415,14 @@ const utils = {
         return parts.join(' ')
     },
 
+    formatAlerts: data => {
+        let summaries = data.alerts.map(
+            alert => alert.annotations.summary || alert.labels.alertname,
+        );
+        let summary = mergeStrings(summaries);
+        return summary;
+    },
+
     parseAlerts: data => {
         /*
         Parse AlertManager data object into an Array of message strings.
@@ -446,6 +432,10 @@ const utils = {
         }
 
         console.log(JSON.stringify(data))
+
+        if (process.env.RESPECT_GROUPBY === "1") {
+            return [utils.formatAlerts(data)]
+        }
 
         let alerts = []
 


### PR DESCRIPTION
This PR introduces a completely refurbished alertmanager-to-matrix transform pipeline, fixing numerous outstanding issues and paving the way for future improvements to be made quickly and straightforwardly. No changes to upstream alerts are required for the new implementation to work correctly, but we can take advantage of the added features incrementally, for example by adjusting the default `group_by` configuration in our Alertmanager.

## group_by implementation

The biggest problem solved here is the lack of `group_by` support in the original matrix-alertmanager project. When multiple similar alerts fire, the `group_by` feature of Alertmanager intelligently groups them together based on your configuration, and sends a single notification covering the entire batch. However, matrix-alertmanager was originally undoing all of this work and bridging the single message from Alertmanager as an entire slew of Matrix messages.

For example, here is how one alert showed up as eight different messages in the old system, basically impossible to read:

<img width="1382" height="1216" alt="image" src="https://github.com/user-attachments/assets/0abd7c37-9f09-4448-8611-966f6ce3b87a" />

Compare that to the new version, in a single message:

<img width="1276" height="246" alt="image" src="https://github.com/user-attachments/assets/0bd36f84-6f5d-4969-ae96-911ef42d445f" />

Firing and resolved alerts are grouped apart, and the alert summaries are intelligently merged, adapting to any input format, so that no information is duplicated.

Inside the disclosure triangle, the labels and annotations that are shared amongst every alert in the group are displayed, followed by the individual instances of the alert, which can be individually expanded to see the additional labels and annotations that vary between the instances:

<img width="1280" height="1042" alt="image" src="https://github.com/user-attachments/assets/90d7d749-b4fa-4057-bd59-80964a7da067" />

(Note that this alert has a needless `description` annotation which duplicates the information already present in the labels. That could be removed to improve readability further.)

## alert summary combining

The alert summarizer uses a custom algorithm based on the [jsdiff](https://github.com/kpdecker/jsdiff) library in order to reliably adapt to any set of provided alert summaries, and automatically pick out the shared text even when it differs in more than one place. For example, consider the following set of alert summaries:

```
ArgoCD app stage1 sync status is Unknown in cluster prod/edge-eu-cuddly-pants
ArgoCD app stage2 sync status is Unknown in cluster prod/edge-eu-cuddly-pants
ArgoCD app stage3 sync status is Unknown in cluster prod/edge-eu-cuddly-pants
ArgoCD app stage1 sync status is Unknown in cluster staging/edge-na-rosy-gift
ArgoCD app stage2 sync status is Unknown in cluster staging/edge-na-rosy-gift
ArgoCD app stage3 sync status is Unknown in cluster staging/edge-na-rosy-gift
ArgoCD app stage1 sync status is OutOfSync in cluster prod/edge-eu-cuddly-pants
ArgoCD app stage2 sync status is OutOfSync in cluster prod/edge-eu-cuddly-pants
ArgoCD app stage3 sync status is OutOfSync in cluster prod/edge-eu-cuddly-pants
ArgoCD app stage1 sync status is OutOfSync in cluster staging/edge-na-rosy-gift
ArgoCD app stage2 sync status is OutOfSync in cluster staging/edge-na-rosy-gift
ArgoCD app stage3 sync status is OutOfSync in cluster staging/edge-na-rosy-gift
```

These would be detected as similar and coalesced as follows, without any need to add hinting to the underlying alert definition:

```
ArgoCD app {stage1, stage2, stage3} sync status is {OutOfSync, Unknown} in cluster {prod, staging}/{edge-eu-cuddly-pants, edge-na-rosy-gift}
```

The algorithm is well-documented in code comments and should be relatively straightforward to understand if fixes are required in future.

## readability improvements

The old implementation attempted to use colors to disambiguate firing from resolved alerts, as well as to disambiguate alert levels. However, in practice, this had two problems:

* Beeper clients have inconsistent support for text color, and the existing messages' color did not render on desktop clients.
* In practice, the only two colors for severity disambiguation used were red and orange, which looked almost identical.

The coloring scheme has now been replaced with emojis since I believe they're much easier to parse visually, and do not impair readability of the underlying text (as, for example, the old implementation's yellow text would do). The emoji scheme is:

|Emoji|Meaning|
|-|-|
|💥|`severity="critical"` (PagerDuty)|
|🚨|`severity="error"`|
|⚠️|`severity="warning"`|
|ℹ️|`severity="info"`|
|✅|resolved alert|

This makes it easy to tell at a glance which alerts were routed to PagerDuty, and makes each level easy to visually distinguish. In case more than one severity of alert is somehow grouped together in the same alert group, multiple emojis will be shown in the summary line, and they will be individually matched to the corresponding alert instances inside the disclosure triangle.

Despite colors no longer being used, I included a working colorization function that prepares colored text that will render correctly on all Beeper clients, just in case a future contributor wishes to re-introduce that feature more robustly.

## better url handling

URLs have been deduplicated. Previously, separate URLs would be rendered for every individual instance of an alert, wasting space and impairing usability (the silence link for an alert would create a silence that did not apply to other, also-firing instances of the same alert).

Now, URLs are dynamically adapted to cover the entire set of firing and resolved alerts in the same alert group. For example:

* The Alertmanager silence link creates a silence that matches only on the labels that are common to all the alerts in the group.
* Rather than a separate log URL being generated for each alert instance, substituting in its unique labels to the configured `logs_template`, a single URL is covered that uses label regexp matching to show logs from each of the firing alerts in the group. No changes to alert definitions are required to make use of this feature.
* Only a single copy of each URL type (alert definition in Grafana, configured runbook, custom dashboard) is rendered in the message. If it's not possible to render a single URL that covers every alert in the group, for example because they differ too greatly in their configuration, the new implementation automatically provides separate numbered URLs for each configuration type; only as many as are actually needed to cover the distinct cases are provided, rather than one for every alert.
* Dashboard URLs with `$env` placeholders, which were not substituted by the previous code, are now handled properly. At present, this only provides a single value for each placeholder, even if the value varies across the firing alerts in the group, although such a case seems unlikely to occur in practice. However, it would be straightforward to use Grafana's multi-select variable feature to cover this case as well.

## general refactoring

Code duplication is significantly reduced, with the concrete result of fixing a number of inconsistencies across different alert types. For example, all Grafana links now populate an accurate time range based on the reported information about the firing alerts, rather than sometimes defaulting to just the last 15 minutes from dashboard load. In addition, the hardcoded cases for automatic Kubernetes log URL synthesis introduced some years ago by Toni have been factored out to a single location and transparently re-use the `log_template` facility rather than needing to duplicate the Grafana URL logic.

## rollout and backtesting

All new functionality is opt-in via the environment variable `RESPECT_GROUPBY=1`, which can be separately applied to the matrix-alertmanager instance in production to control the rollout. In addition, I've arranged matrix-alertmanager to run locally against a Beeper room in staging, and have pulled the last 30 days of alerts that were sent to bc-infra in order to backtest and verify that none trigger crashes or other serious misbehavior.
