### PR TITLE
Add some commonsense limits for alert formatting

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,10 @@
 const jsdiff = require('diff');
 
+const limits = {
+    summaryAlts: 25,
+    detailAlts: 10,
+}
+
 const segmentString = (string) => {
     return Array.from(string.matchAll(/[a-z0-9.-]+|[^a-z0-9.-]+/gi), match => match[0]);
 }
@@ -212,11 +217,18 @@ const mergeStrings = (strings) => {
         : (unchangedIdx < unchangedRanges.length)
     ) {
         if (onVarying) {
-            let variants = new Set();
+            let variantSet = new Set();
             for (const list of varyingLists) {
-                variants.add(list[varyingIdx]);
+                variantSet.add(list[varyingIdx]);
             }
-            combined.push("{" + [...variants].sort().join(", ") + "}");
+            variants = [...variantSet].sort();
+            if (variants.length > limits.summaryAlts) {
+                const numIncluded = limits.summaryAlts - 1;
+                const numOmitted = variants.length - numIncluded;
+                variants = variants.slice(0, numIncluded);
+                variants.push(`... ${numOmitted} more`);
+            }
+            combined.push("{" + variants.join(", ") + "}");
 
             varyingIdx += 1;
             onVarying = false;
@@ -527,6 +539,10 @@ const utils = {
                 parts.push(` <br>${nbsp}`);
                 let alertNum = 1;
                 for (const alert of alerts) {
+                    if (alertNum > limits.detailAlts) {
+                        parts.push(`(... and ${alerts.length - limits.detailAlts} more)`);
+                        break;
+                    }
                     const emoji = (
                         statusEmojis[alert.status] ||
                         severityEmojis[alert.labels.severity] ||

--- a/src/utils.js
+++ b/src/utils.js
@@ -221,7 +221,7 @@ const mergeStrings = (strings) => {
             for (const list of varyingLists) {
                 variantSet.add(list[varyingIdx]);
             }
-            variants = [...variantSet].sort();
+            let variants = [...variantSet].sort();
             if (variants.length > limits.summaryAlts) {
                 const numIncluded = limits.summaryAlts - 1;
                 const numOmitted = variants.length - numIncluded;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,9 +1,9 @@
 const jsdiff = require('diff');
 
 const limits = {
-    summaryAlts: 25,
-    detailAlts: 10,
-}
+    summaryAlts: parseInt(process.env.MAX_SUMMARY_ALTS, 10) || 25,
+    detailAlts: parseInt(process.env.MAX_DETAIL_ALTS, 10) || 10,
+};
 
 const segmentString = (string) => {
     return Array.from(string.matchAll(/[a-z0-9.-]+|[^a-z0-9.-]+/gi), match => match[0]);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,8 @@
 const jsdiff = require('diff');
 
 const limits = {
-    summaryAlts: parseInt(process.env.MAX_SUMMARY_ALTS, 10) || 25,
-    detailAlts: parseInt(process.env.MAX_DETAIL_ALTS, 10) || 10,
+    summaryAlts: Math.max(3, parseInt(process.env.MAX_SUMMARY_ALTS, 10) || 25),
+    detailAlts: Math.max(1, parseInt(process.env.MAX_DETAIL_ALTS, 10) || 10),
 };
 
 const segmentString = (string) => {


### PR DESCRIPTION
In case matrix-alertmanager gets an alert that has like 100+ different instances, because of unusual group_by configuration, have it elide some of the excessive details in order to not make an absolutely megachonkers Matrix message (especially not one that is more than 65KiB and is prohibited by the protocol).